### PR TITLE
Update measurement loading to account for manually labeled measurements

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -39,6 +39,9 @@ def to_state(i: int) -> State:
         return State.HOLD
     if i == 3:
         return State.RELEASE
+    if i == 4:
+        # This is a label for rest anomalies, but for now we just treat them as rest.
+        return State.REST
     err = ValueError("Invalid State int representation passed as argument.")
     raise err
 

--- a/src/dataset_loading.py
+++ b/src/dataset_loading.py
@@ -37,8 +37,8 @@ def load_myoflex_data_file(filepath: Path) -> Data:
 
 def load_our_data_file(filepath: Path) -> Data:
     """Read the data from our data file."""
-    readings = pd.read_csv(filepath, index_col=0, names=["time", "voltage", "label"])
-    voltages = readings["voltage"]
+    readings = pd.read_csv(filepath, index_col=0, header=0)
+    voltages = readings["measurement"]
 
     labels = [to_state(label) for label in readings["label"]]
 


### PR DESCRIPTION
The manually labeled measurements include a fifth state for rest anomalies, and the csv files now contain a header